### PR TITLE
Commits view refactor to use React Router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,6 +7545,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7553,6 +7566,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hoopy": {
@@ -10591,6 +10612,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -13274,6 +13304,52 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.2.tgz",
@@ -13750,6 +13826,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -15606,6 +15687,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -16094,6 +16185,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16194,6 +16290,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -16211,6 +16308,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16241,6 +16339,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -16252,6 +16351,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16302,6 +16402,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -16310,6 +16411,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16320,6 +16422,7 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -16375,6 +16478,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-icons": "^4.2.0",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "react-test-renderer": "^17.0.1",
     "web-vitals": "^1.1.0"

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,31 @@
 import React from "react";
+import {Route, Switch, Redirect, BrowserRouter as Router } from 'react-router-dom';
 import RepoScreen from "./components/RepoScreen/RepoScreen";
+import CommitsScreen from "./components/CommitsScreen/CommitsScreen";
 
 function App() {
   return (
-    <>
-      <RepoScreen />
-    </>
+    <Router>
+        <Switch>
+            <Route exact path={'/'}
+                   render={() => {
+                       return <Redirect to={'/repo-screen'}/>
+                   }}
+            />
+            <Route path={'/repo-screen'}
+                   render={props => (
+                       <RepoScreen {...props}/>
+                   )}
+            />
+
+            <Route path={'/commits/:owner/:name'}
+                   render={props => (
+                       <CommitsScreen {...props}/>
+                   )}
+            />
+
+        </Switch>
+    </Router>
   );
 }
 

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Avatar from "../Avatar/Avatar";
 import Title from "../Title/Title";
-import Button from "../Button/Button";
+import {Link} from "react-router-dom";
 import "./Card.scss";
 
 const Card = ({
@@ -12,11 +12,7 @@ const Card = ({
   avatarUrl,
   dataObj,
   subIcon,
-  onClick,
 }) => {
-  const onCommitClick = () => {
-    onClick(dataObj);
-  };
 
   return (
     <div className="card">
@@ -32,12 +28,7 @@ const Card = ({
             {link}
           </a>
         </p>
-        <Button
-          label={"View Commits"}
-          color={"#007bff"}
-          tooltip={"View commits made in the last 24 hours"}
-          onClick={onCommitClick}
-        />
+        <Link to={`/commits/${dataObj.owner.login}/${dataObj.name}`} title={"View commits made in the last 24 hours"}>View Commits</Link>
       </div>
     </div>
   );

--- a/src/components/CommitsScreen/CommitsScreen.js
+++ b/src/components/CommitsScreen/CommitsScreen.js
@@ -14,7 +14,7 @@ import './CommitsScreen.scss';
 
 
 const CommitsScreen = () => {
-    let {owner, name} = useParams();
+    const {owner, name} = useParams();
     const [commits, setCommits] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
     const today = moment().toISOString(true);

--- a/src/components/CommitsScreen/CommitsScreen.js
+++ b/src/components/CommitsScreen/CommitsScreen.js
@@ -1,0 +1,52 @@
+import React, {useEffect, useState} from "react";
+import {
+    useParams,
+    Link
+} from "react-router-dom";
+import {getCommits} from "../../services/githubService";
+import List from "../List/List";
+import Title from "../Title/Title";
+import EmptyDisplay from "../EmptyDisplay/EmptyDisplay";
+import Loader from "../Loader/Loader";
+import {formatDateByDay} from "../../utils/helpers";
+import moment from "moment";
+import './CommitsScreen.scss';
+
+
+const CommitsScreen = () => {
+    let {owner, name} = useParams();
+    const [commits, setCommits] = useState([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const today = moment().toISOString(true);
+
+
+    useEffect(() => {
+        setIsLoading(true)
+        getCommits(owner, name).then((data) => {
+            setCommits(data)
+            setIsLoading(false)
+        })
+    }, [])
+
+    let commitsContent;
+    if (isLoading) {
+        commitsContent = <Loader message="Getting commits..." />;
+    } else if (commits.length > 0) {
+        commitsContent = <List data={commits} />;
+    } else {
+        commitsContent = <EmptyDisplay message="No recent commits to display" />;
+    }
+
+    return (
+        <div className="commits-screen-container">
+            <div className="commits-screen-header">
+                <Link to="/">Back</Link>
+                <Title title={`Commits on ${formatDateByDay(today)}`}/>
+            </div>
+            {commitsContent}
+        </div>
+    )
+}
+
+
+export default CommitsScreen;

--- a/src/components/CommitsScreen/CommitsScreen.scss
+++ b/src/components/CommitsScreen/CommitsScreen.scss
@@ -1,0 +1,14 @@
+.commits-screen-container {
+  height: 100vh;
+
+  .commits-screen-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px 0 20px;
+  }
+
+}
+
+

--- a/src/components/List/List.scss
+++ b/src/components/List/List.scss
@@ -1,5 +1,6 @@
 .list-container {
   list-style-type: none;
-  padding: 0;
-  margin-top: 0;
+  padding: 50px 60px 50px 60px;
+  overflow-x: scroll;
+  height: 70vh;
 }

--- a/src/components/RepoScreen/RepoScreen.js
+++ b/src/components/RepoScreen/RepoScreen.js
@@ -1,48 +1,23 @@
 import React, { useState, useEffect } from "react";
 import { FaGithub } from "react-icons/fa";
 import { FiStar } from "react-icons/fi";
-import { getStarredRepos, getCommits } from "../../services/githubService";
-import { formatDateByDay } from "../../utils/helpers";
+import { getStarredRepos } from "../../services/githubService";
 import Navbar from "../Navbar/Navbar";
 import Loader from "../Loader/Loader";
 import Card from "../Card/Card";
-import Modal from "../Modal/Modal";
 import ScrollArrow from "../ScrollArrow/ScrollArrow";
-import List from "../List/List";
-import EmptyDisplay from "../EmptyDisplay/EmptyDisplay";
-import moment from "moment";
 import "./RepoScreen.scss";
 
 const RepoScreen = () => {
   const [repos, setRepos] = useState([]);
-  const [commits, setCommits] = useState([]);
-  const [show, setShow] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const today = moment().toISOString(true);
 
   useEffect(() => {
     // fetch top repos on initial mounting
-    setIsLoading(true);
     getStarredRepos().then((data) => {
       setRepos(data.items);
-      setIsLoading(false);
     });
   }, []);
 
-  const handleCardClick = (dataObj) => {
-    setShow(true);
-    setIsLoading(true);
-    getCommits(dataObj).then((data) => {
-      // fetch commits on button press
-      setCommits(data);
-      setIsLoading(false);
-    });
-  };
-
-  const onModalClose = () => {
-    setShow(false);
-    setCommits([]);
-  };
 
   let content = <Loader message="Loading..." />;
   if (repos.length) {
@@ -56,18 +31,8 @@ const RepoScreen = () => {
         icon={<FaGithub size={150} style={{ marginTop: 5 }} />}
         subIcon={<FiStar size={15} fill="yellow" />}
         dataObj={repo}
-        onClick={handleCardClick}
       />
     ));
-  }
-
-  let modalContent;
-  if (isLoading) {
-    modalContent = <Loader message="Getting commits..." />;
-  } else if (commits.length > 0) {
-    modalContent = <List data={commits} />;
-  } else {
-    modalContent = <EmptyDisplay message="No recent commits to display" />;
   }
 
   return (
@@ -77,14 +42,6 @@ const RepoScreen = () => {
 
       <div className="container">
         {content}
-
-        <Modal
-          show={show}
-          onClose={onModalClose}
-          header={`Commits on ${formatDateByDay(today)}`}
-        >
-          {modalContent}
-        </Modal>
       </div>
 
       <div className="scroll-top-container">

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -19,10 +19,8 @@ export async function getStarredRepos() {
   }
 }
 
-export async function getCommits(repo) {
+export async function getCommits(owner, repository) {
   // fetches commits made in the past 24 hours for a repository
-  const owner = repo.owner.login;
-  const repository = repo.name;
   const today = moment().toISOString(true);
   const yesterday = moment(today).subtract(24, "hours").toISOString(true);
 


### PR DESCRIPTION
## Description
Refactors how a user views commits for repository. Now, instead of viewing a commit list inside of a modal, the user gets routed to a different page where the commits are fetched and displayed 

## Demo
![view_commits](https://user-images.githubusercontent.com/3916140/110372712-7d471600-8003-11eb-8666-617dd192bb71.gif)



## Additional Notes and Todos
- Now that the modal isn't being used, a proper cleanup of all the relevant files needs to be done. I don't want to completely get rid of it yet without some more feedback on the initial implementation. 
- With more time, a more nicely styled Commits Screen could be made. 
- With the addition of the new Commits Screen, additional tests need to be made as well. 